### PR TITLE
fix import of google/protobuf/timestamp.proto

### DIFF
--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -47,7 +47,8 @@ def get_imports(attr):
     direct = dict()
     for dep in proto_deps:
         for src in dep[ProtoInfo].check_deps_sources.to_list():
-            direct["{}={}".format(proto_path(src, dep[ProtoInfo]), attr.importpath)] = True
+            if not proto_path(src, dep[ProtoInfo]).startswith("google/protobuf/"):
+                direct["{}={}".format(proto_path(src, dep[ProtoInfo]), attr.importpath)] = True
 
     deps = getattr(attr, "deps", []) + getattr(attr, "embed", [])
     transitive = [


### PR DESCRIPTION
ref: https://github.com/bazelbuild/rules_go/issues/2927

WORKSPACE file snippet:

```starlark
git_repository(
    name = "io_bazel_rules_go",
    commit = "a6678449764fcd172550fe3218fa6aa03cc8bede",
    remote = "git@github.com:xflagstudio/rules_go.git",
    shallow_since = "1630391768 +0900",
)
```